### PR TITLE
Expandir loja e itens de raças no RPG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ botDiscord/
 Thumbs.db
 poo.py
 acesso.py
+feedback.txt

--- a/cogs/players.py
+++ b/cogs/players.py
@@ -124,6 +124,23 @@ class Players(commands.Cog):
         txt = "\n".join([f"🔹 **{m['missao']}**: {', '.join(m['herois'])}" for m in reversed(missoes)])
         await ctx.send(embed=discord.Embed(title="📖 Crônicas", description=txt))
 
+    @commands.command(name="dado", aliases=["roll", "r"])
+    async def dado(self, ctx, formula: str = "1d20"):
+        """Rola dados. Ex: !dado 2d6 ou !dado 1d100"""
+        try:
+            # Importamos a função de lógica
+            from cogs.logic import rolar_dado
+            
+            resultado = rolar_dado(formula)
+            embed = discord.Embed(
+                title="🎲 O Dado Rolou!",
+                description=f"**Resultado:** `{resultado}`\n**Fórmula:** `{formula}`",
+                color=0x9b59b6
+            )
+            embed.set_footer(text=f"Lançado por {ctx.author.name}")
+            await ctx.send(embed=embed)
+        except Exception:
+            await ctx.send("🐾 **Lulu:** Formato inválido! Use algo como `!dado 1d20`.")
 
 # ESSA PARTE É OBRIGATÓRIA NO FINAL DO ARQUIVO:
 async def setup(bot):

--- a/constantes.py
+++ b/constantes.py
@@ -82,14 +82,56 @@ LOJA_ITENS = {
     "elfos": {
         "Flechas de Sol": {"preco": 180, "dano_bonus": 3, "desc": "+3 de dano. Rapidez solar."},
         "Sangue do Cupido": {"preco": 700, "mod_dt": -2, "desc": "Diminui 2 da DT do teste."},
-        "Presilhas Trevo": {"preco": 550, "mod_dt_global": -3, "desc": "Diminui 3 da DT de todos os testes."}
+        "Presilhas Trevo": {"preco": 550, "mod_dt_global": -3, "desc": "Diminui 3 da DT de todos os testes."},
+        "Brincos de Frey": {"preco": 560, "carisma_bonus": 3, "duracao": "cena", "desc": "+3 de carisma em todo teste durante uma cena."},
+        "Meias do Desaparecimento Parcial": {"preco": 600, "efeito": "invisibilidade_parcial", "desc": "Torna o usuário invisível da cintura para baixo."},
+        "Cenouras Cantantes": {"preco": 120, "efeito": "atordoar", "quantidade": 3, "desc": "Grito afinado que atordoa inimigos."}
     },
     "khaerun": {
-        "Martelo do Eco Profundo": {"preco": 1200, "dado": "2d8", "desc": "Impacto reverberante."},
-        "Escudo da Vigília Ancestral": {"preco": 1100, "escudo_bonus": 6, "desc": "+6 de Escudo."},
-        "Marca da Exclusão": {"preco": 0, "custo_especial": "asa_fada + olho_dragao", "defesa": 7, "usos": 3}
+        "Martelo do Eco Profundo": {"preco": 1200, "dado": "2d8", "desc": "Impacto reverberante. Pode derrubar ou atordoar."},
+        "Escudo da Vigília Ancestral": {"preco": 1100, "escudo_bonus": 6, "desc": "+6 de Escudo. Resistência extrema."},
+        "Machado das Runas de Sangue": {"preco": 1500, "dano_portador": "1d4", "dano_adversario": "1d10", "desc": "-1d4 no portador, 1d10 no adversário + dano perdido."},
+        "Elmo da Rocha Silenciosa": {"preco": 950, "presenca_bonus": 2, "agilidade_bonus": 2, "desc": "+2 presença e agilidade. Imunidade a medo e intimidação."},
+        "Corrente do Conselho Partido": {"preco": 600, "efeito": "autoridade_ancestral", "desc": "Impõe respeito em assembleias e negociações."},
+        "Proibida": {"preco": 1900, "dado_area": "1d30", "alcance": 10, "desc": "+1d30 de dano em área (10m). Mercadoria proibida."}
+    },
+    "fadas": {
+        "Véu da Última Lembrança": {"preco": 450, "efeito": "imunidade_medo", "desc": "Apaga lembrança dolorosa. Imunidade a medo, culpa ou trauma."},
+        "Pulseiras do Batimento Lúmino": {"preco": 350, "carisma_bonus": 3, "desc": "+3 de carisma. Aumenta empatia e persuasão."},
+        "Frasco de Luz Engarrafada": {"preco": 300, "dado_dano": "1d6", "alvo": "coracoes_corrompidos", "desc": "1d6 de dano em corações corrompidos. Purifica maldições."},
+        "Asas de Orvalho Esquecido": {"preco": 520, "efeito": "levitacao", "desc": "Levitação e movimento silencioso."},
+        "Colar do Nome Verdadeiro": {"preco": 480, "dt_mentira": 18, "desc": "DT 18 para qualquer um que quiser mentir para o usuário."},
+        "Sementes do Recomeço Lento": {"preco": 250, "dado_cura_area": "1d15", "alvos_max": 3, "desc": "+1d15 de cura em área (até 3 criaturas)."}
+    },
+    "bruxas": {
+        "Poção do Amor": {"preco": 266, "efeito": "fascinacao", "duracao": "1 dia", "desc": "Atração intensa. Elo de fascínio por um dia."},
+        "Poção do Esquecimento": {"preco": 350, "efeito": "apagar_memoria", "desc": "Apaga lembranças específicas."},
+        "Poção da Raiva": {"preco": 300, "efeito": "furia", "duracao": "1 dia", "desc": "Fúria ardente contra um indivíduo por um dia."},
+        "Poção da Verdade": {"preco": 550, "efeito": "revelar_verdade", "desc": "Obriga a revelar pensamentos íntimos. Impossibilita mentiras."},
+        "Poção da Sorte": {"preco": 170, "efeito": "sorte", "desc": "Ganha moedas ou item aleatório."},
+        "Poção do Tempo Velado": {"preco": 500, "dado_cura": "1d10", "desc": "+1d10 de vida. Manipula o próprio tempo."}
+    },
+    "drows": {
+        "Lâminas Irmãs de Ardósia": {"preco": 700, "dado": "2d6", "efeito": "sangramento_cegueira", "desc": "2d6 de dano. Sangramento progressivo e cegueira temporária."},
+        "Manto da Penumbra Vingativa": {"preco": 480, "efeito": "invisibilidade_parcial", "desc": "Invisibilidade parcial em sombras. Bônus em ataques surpresa."},
+        "Anel do Exílio Antigo": {"preco": 350, "dado_dano": "1d6", "alvos": ["Elfo", "Fada", "Khaerun"], "desc": "+1d6 de dano em Elfos, Fadas, Khaerun."},
+        "Veneno da Lua Incerta": {"preco": 200, "efeito_sucesso": "paralisia_inimigo", "efeito_falha": "paralisia_usuario", "desc": "Sucesso/Glória: paralisa inimigo. Falha/Ruína: paralisa usuário."},
+        "Oráculo de Obsidiana Quebrada": {"preco": 420, "efeito": "prever_movimento", "desc": "Prevê o próximo movimento de um inimigo."},
+        "Capa do Passo Arriscado": {"preco": 400, "efeito": "atravessar_vigiados", "usos_por_noite": 1, "desc": "Atravessa áreas vigiadas sem ser notado. 1 uso por noite."}
+    },
+    "humanos": {
+        "Espada do Juramento Quebrado": {"preco": 650, "dado": "1d8", "desc": "1d8 de dano. Maior dano com culpa/arrependimento."},
+        "Broche da Bandeira Invisível": {"preco": 280, "presenca_bonus": 5, "desc": "+5 de presença. Bônus de moral e liderança."},
+        "Frascos de Alquimia Errante": {"preco": 400, "dado_cura": "1d4", "efeito": "colateral_aleatorio", "desc": "1d4 de cura + efeito colateral aleatório."},
+        "Dado do Destino Ambulante": {"preco": 250, "efeito_sucesso": "bonus_elevado_ou_sucesso_auto", "efeito_falha": "complicacoes_narrativas", "desc": "Teste de Sorte: Sucesso = bônus. Falha = complicações."},
+        "Poção do Quase Milagre": {"preco": 3000, "dado_cura": "1d20", "efeito_sucesso": "recuperacao_surpreendente", "efeito_falha": "cura_incompleta", "desc": "1d20 de cura. Teste de Sorte determina eficácia."},
+        "Contrato de Areia": {"preco": 200, "efeito_sucesso": "acordo_favoravel", "efeito_falha": "clausulas_ocultas", "desc": "Vantagem em negociações. Teste de Sorte."}
+    },
+    "fragmentados": {
+        "Sino da Repulsão Abissal": {"preco": 800, "efeito": "expulsar_nao_humanos", "desc": "Expulsa criaturas não humanas em área ampla."},
+        "Cinzas do Nome Perdido": {"preco": 600, "efeito": "repelir_especies", "desc": "Força criaturas de outras espécies a recuar."},
+        "Marca da Exclusão": {"preco": 0, "custo_especial": "asa_fada + olho_dragao", "defesa": 7, "usos": 3, "desc": "+7 de defesa. Protege 3 ataques. Espécies não humanas não se aproximam."}
     }
-    # ... as outras seguem o mesmo padrão
 }
 
 # Itens que podem ser ganhos ao usar a Poção da Sorte (itens de tier baixo/médio)

--- a/views.py
+++ b/views.py
@@ -42,10 +42,13 @@ class LojaView(discord.ui.View):
     @discord.ui.select(
         placeholder="Escolha a ala da loja...",
         options=[
-            discord.SelectOption(label="Elfos de Elandor", value="elfos", emoji="🍃"),
-            discord.SelectOption(label="Khaerun de Kharr-Dum", value="khaerun", emoji="⚒️"),
-            discord.SelectOption(label="Fadas de Íris", value="fadas", emoji="✨"),
-            discord.SelectOption(label="Casa das Bruxas", value="bruxas", emoji="🧪")
+            discord.SelectOption(label="O Vel", value="elfos", emoji="🍃"),
+            discord.SelectOption(label="Rochas e Runas", value="khaerun", emoji="⚒️"),
+            discord.SelectOption(label="Loja de Íris", value="fadas", emoji="✨"),
+            discord.SelectOption(label="Casa das Bruxas", value="bruxas", emoji="🧪"),
+            discord.SelectOption(label="Veneno Silencioso", value="drows", emoji="💀"),
+            discord.SelectOption(label="A Caravna do Deserto", value="humanos", emoji="🏜️"),
+            discord.SelectOption(label="O Altar", value="fragmentados", emoji="⛩️")
         ]
     )
     async def select_categoria(self, interaction: discord.Interaction, select: discord.ui.Select):


### PR DESCRIPTION
Adiciona novos itens exclusivos para as raças fadas, bruxas, drows, humanos e fragmentados em constantes.py. Atualiza as opções de seleção de categoria na loja para refletir as novas alas e nomes temáticos. Implementa comando de rolagem de dados (!dado) no cog de players. Atualiza .gitignore para incluir feedback.txt.