### PR TITLE
Converter comandos para hybrid_command para o bot

### DIFF
--- a/cogs/combate.py
+++ b/cogs/combate.py
@@ -59,8 +59,8 @@ class Combate(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
-    async def batalha(ctx, op1: discord.Member, op2: discord.Member):
+    @commands.hybrid_command(name="batalha", description="Inicia um duelo entre dois jogadores (ADMs apenas)")
+    async def batalha(self, ctx, op1: discord.Member, op2: discord.Member):
         """Inicia um duelo entre dois jogadores usando a BatalhaView."""
         if not eh_admin(ctx): 
             return await ctx.send("🐾 **Lulu:** Apenas mestres podem abrir a arena.")

--- a/cogs/habilidades.py
+++ b/cogs/habilidades.py
@@ -1,18 +1,17 @@
 import discord
 from discord.ext import commands
 import json
-import random # Import correto
+import random 
 from database import carregar_dados, salvar_dados
 import constantes
-# Importando o nome correto da função que você criou
 from habilidades_logic import processar_uso_habilidade 
 
 class Habilidades(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
-    async def usar(self, ctx, *, habilidade: str): # Adicionado self
+    @commands.hybrid_command(name="usar", description="Usa uma habilidade disponível")
+    async def usar(self, ctx, *, habilidade: str):
         user_id = str(ctx.author.id)
         dados = carregar_dados()
         p = dados["usuarios"].get(user_id)

--- a/cogs/mestre.py
+++ b/cogs/mestre.py
@@ -12,7 +12,7 @@ class Mestre(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
+    @commands.hybrid_command(name="upar", description="Sobe o nível de um jogador (ADMs apenas)")
     async def upar(self, self_ctx, alvo: discord.Member, n: int = 1): # Adicionado self
         ctx = self_ctx # Apenas para manter seu código igual abaixo
         if not eh_admin(ctx): return
@@ -47,7 +47,7 @@ class Mestre(commands.Cog):
             
             await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.hybrid_command(name="dar_xp", description="Dá XP a um jogador (ADMs apenas)")
     @commands.has_permissions(administrator=True)
     async def dar_xp(self, ctx, alvo: discord.Member, quantidade: int):
         dados = carregar_dados()
@@ -63,7 +63,7 @@ class Mestre(commands.Cog):
             
             await ctx.send(msg)
 
-    @commands.command()
+    @commands.hybrid_command(name="lulu_reset", description="Dá cargas de descanso para todos (ADMs apenas)")
     @commands.has_permissions(administrator=True) # Só você ou ADMs podem usar
     async def lulu_reset(self, ctx, quantidade: int = 1):
         dados = carregar_dados()
@@ -76,7 +76,7 @@ class Mestre(commands.Cog):
         salvar_dados(dados)
         await ctx.send(f"🐾 **Lulu:** Recuperei o fôlego de todos! Adicionei **{quantidade}** carga(s) de descanso para o grupo.")
 
-    @commands.command()
+    @commands.hybrid_command(name="lulu_azar", description="Amaldiçoa um jogador com azar (-5 na próxima rolagem) (ADMs apenas)")
     @commands.has_permissions(administrator=True)
     async def lulu_azar(self, ctx, alvo: discord.Member):
         dados = carregar_dados()
@@ -86,7 +86,7 @@ class Mestre(commands.Cog):
             salvar_dados(dados)
             await ctx.send(f"💀 **Lulu rosnou para {alvo.name}!** A nuvem do azar agora te persegue (-5 na próxima rolagem).")
 
-    @commands.command()
+    @commands.hybrid_command(name="setar", description="Define um atributo ou valor para um jogador (ADMs apenas)")
     async def setar(self, ctx, alvo: discord.Member, at: str, v: int):
         if not eh_admin(ctx): return
         dados = carregar_dados()
@@ -97,13 +97,12 @@ class Mestre(commands.Cog):
             salvar_dados(dados)
             await ctx.send(f"✅ {at} de {alvo.name} setado para {v}.")
 
-    @commands.command()
+    @commands.hybrid_command(name="concluir_missao", description="Conclui uma missão e distribui recompensas (ADMs apenas)")
     @commands.has_permissions(administrator=True)
-    async def concluir_missao(self, ctx): # Adicionado self
+    async def concluir_missao(self, ctx):
         def check(m): return m.author == ctx.author and m.channel == ctx.channel
         try:
             await ctx.send("📝 Nome da Missão?")
-            # MUDANÇA AQUI: de bot.wait_for para self.bot.wait_for
             msg_nome = await self.bot.wait_for("message", timeout=30, check=check)
             nome = msg_nome.content
             
@@ -126,7 +125,7 @@ class Mestre(commands.Cog):
             print(e)
             await ctx.send("🐾 **Lulu:** Erro no registro ou tempo esgotado.")
 
-    @commands.command()
+    @commands.hybrid_command(name="sorteio_missao", description="Sorteia uma equipe diversificada para uma missão (ADMs apenas)")
     async def sorteio_missao(self, ctx):
         if not eh_admin(ctx): return
         dados = carregar_dados()
@@ -141,7 +140,7 @@ class Mestre(commands.Cog):
         if len(equipe) < 5: return await ctx.send("🐾 **Lulu:** Diversidade de raças insuficiente.")
         await ctx.send(f"⚔️ **Escolhidos:**\n" + "\n".join([f"🔸 {n}" for n in equipe]))
 
-    @commands.command()
+    @commands.hybrid_command(name="evento", description="Cria um desafio para todos os jogadores com ficha (ADMs apenas)")
     async def evento(self, ctx, nome: str, dt: int, atributo: str, dano: int):
         """
         Cria um desafio para TODOS os jogadores com ficha.

--- a/cogs/players.py
+++ b/cogs/players.py
@@ -8,7 +8,7 @@ class Players(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
+    @commands.hybrid_command(name="ficha", description="Mostra sua ficha de personagem")
     async def ficha(self, ctx, alvo: discord.Member = None):
         alvo = alvo or ctx.author
         p = carregar_dados()["usuarios"].get(str(alvo.id))
@@ -42,7 +42,7 @@ class Players(commands.Cog):
         
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.hybrid_command(name="descansar", description="Recupera pontos de vida usando descansos")
     async def descansar(self, ctx):
         user_id = str(ctx.author.id)
         dados = carregar_dados()
@@ -89,14 +89,14 @@ class Players(commands.Cog):
         salvar_dados(dados)
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.hybrid_command(name="inventario", description="Mostra seu inventário e saldo")
     async def inventario(self, ctx):
         p = carregar_dados()["usuarios"].get(str(ctx.author.id))
         if not p: return await ctx.send("🐾 **Lulu:** Registre-se.")
         inv = ", ".join(p["inventario"]) if p["inventario"] else "Vazio"
         await ctx.send(embed=discord.Embed(title=f"🎒 {ctx.author.name}", description=f"**Itens:** {inv}\n**Saldo:** {p['dinheiro']} Krugs"))
 
-    @commands.command()
+    @commands.hybrid_command(name="beber", description="Usa um item do inventário")
     async def beber(self,ctx, *, item: str):
         user_id = str(ctx.author.id)
         dados = carregar_dados()
@@ -117,14 +117,14 @@ class Players(commands.Cog):
             await ctx.send(f"⏳ Tempo manipulado! Recuperou {cura} PV.")
         else: await ctx.send("🐾 **Lulu:** Isso não se bebe.")
 
-    @commands.command()
+    @commands.hybrid_command(name="historico", description="Mostra as últimas missões")
     async def historico(self, ctx):
         missoes = carregar_dados().get("missoes", [])[-5:]
         if not missoes: return await ctx.send("🐾 **Lulu:** Sem história.")
         txt = "\n".join([f"🔹 **{m['missao']}**: {', '.join(m['herois'])}" for m in reversed(missoes)])
         await ctx.send(embed=discord.Embed(title="📖 Crônicas", description=txt))
 
-    @commands.command(name="dado", aliases=["roll", "r"])
+    @commands.hybrid_command(name="dado", aliases=["roll", "r"], description="Rola dados. Ex: !dado 2d6 ou !dado 1d100")
     async def dado(self, ctx, formula: str = "1d20"):
         """Rola dados. Ex: !dado 2d6 ou !dado 1d100"""
         try:

--- a/cogs/sistema.py
+++ b/cogs/sistema.py
@@ -8,7 +8,7 @@ class Sistema(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
     
-    @commands.command()
+    @commands.hybrid_command(name="registrar", description="Registra um novo jogador no sistema")
     async def registrar(self, ctx):
         user_id = str(ctx.author.id)
         dados = carregar_dados()
@@ -59,7 +59,7 @@ class Sistema(commands.Cog):
         salvar_dados(dados)
         await msg.edit(content=f"✨ **Mestre Lulu:** Ficha de {ctx.author.name} gravada! Bem-vindo ao RPG.", embed=None, view=None)
 
-    @commands.command()
+    @commands.hybrid_command(name="loja", description="Mostra a loja de itens disponíveis")
     async def loja(self, ctx):
         dados = carregar_dados()
         cat = constantes.LOJA_ITENS.copy()
@@ -69,11 +69,12 @@ class Sistema(commands.Cog):
                 else: cat[c] = it
         await ctx.send("🐾 **Mestre Lulu:** Não toque em nada.", view=LojaView(cat))
 
-    @commands.command()
+    @commands.hybrid_command(name="lulu_ajuda", description="Mostra o manual de ordens do Mestre Lulu")
     async def lulu_ajuda(self, ctx):
+        """Mostra o manual de ordens do Mestre Lulu."""
         embed = discord.Embed(
-            title="🐾 Central de Ajuda da Lulu",
-            description="Olá! Eu sou a Lulu, a guardiã da sua jornada. Aqui estão as ordens que eu entendo:",
+            title="🐾 Central de Ajuda do Mestre Lulu",
+            description="Olá! Eu sou o Mestre Lulu, o guardião da sua jornada. Aqui estão as ordens que eu entendo:",
             color=0x71368a
         )
         
@@ -87,7 +88,7 @@ class Sistema(commands.Cog):
         )
         embed.add_field(name="⚔️ Ação e Aventura", value=aventura, inline=False)
 
-        # Seção de Regras Lulu (Interação)
+        # Seção de Regras (Interação)
         regras = (
             "• **Sucesso:** Tire um valor igual ou maior que a DT.\n"
             "• **Azar:** Se você estiver azarado (💀), sua próxima rolagem tem -5.\n"
@@ -95,7 +96,7 @@ class Sistema(commands.Cog):
         )
         embed.add_field(name="📜 Regras Rápidas", value=regras, inline=False)
 
-        # Seção para o Mestre (Só aparece se quem digitou for Admin)
+        # Seção para o Mestre
         if ctx.author.guild_permissions.administrator:
             mestre = (
                 "**!registrar @usuario <raça>** - Cria uma nova ficha.\n"
@@ -105,8 +106,9 @@ class Sistema(commands.Cog):
             )
             embed.add_field(name="👑 Comandos de Mestre", value=mestre, inline=False)
 
-        embed.set_footer(text="A Lulu está de olho em você! Boa sorte na mesa.")
-        embed.set_thumbnail(url="URL_DE_UMA_IMAGEM_DA_LULU_SE_TIVER") # Opcional
+        embed.set_footer(text="O Mestre Lulu está de olho em você! Boa sorte na mesa.")
+        if self.bot.user.avatar:
+            embed.set_thumbnail(url=self.bot.user.avatar.url)
 
         await ctx.send(embed=embed)
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ async def load_extensions():
 # --- EVENTOS ---
 @bot.event
 async def on_ready():
+    await bot.tree.sync()
     print(f"🐾 Mestre Lulu online como {bot.user}")
 
 @bot.command()


### PR DESCRIPTION
Todos os comandos do bot no Cogs foram atualizados de @commands.command para @commands.hybrid_command, permitindo o uso de comandos com prefixo e com barra. Descrições e nomes foram adicionados para melhor integração com a ajuda. O bot agora sincroniza a árvore de comandos na inicialização para registrar automaticamente os comandos com barra.