### PR TITLE
fix: Restringir a edição de atributos ao autor do comando

### DIFF
--- a/cogs/sistema.py
+++ b/cogs/sistema.py
@@ -15,7 +15,6 @@ class Sistema(commands.Cog):
         if user_id in dados["usuarios"]:
             return await ctx.send("🐾 **Mestre Lulu:** Tu já tens uma ficha.")
 
-        # 1. Seleção de Raça
         view_raca = SelecaoRacaView(list(constantes.RACAS.keys()))
         msg = await ctx.send("🐾 **Mestre Lulu:** Escolha sua linhagem:", view=view_raca)
         await view_raca.wait()
@@ -25,7 +24,6 @@ class Sistema(commands.Cog):
 
         raca = view_raca.raca_escolhida
 
-        # 2. Distribuição de Pontos
         view_pts = DistribuiPontosView(ctx, raca)
         await msg.edit(content=None, embed=view_pts.gerar_embed(), view=view_pts)
         await view_pts.wait()
@@ -33,8 +31,6 @@ class Sistema(commands.Cog):
         if not view_pts.finalizado:
             return await msg.edit(content="🐾 **Lulu:** Cancelado por inatividade.", embed=None, view=None)
 
-        # 3. Salvando Tudo
-        # Mapeamos os nomes da View para as chaves do Banco de Dados
         res = view_pts.attrs
         dados["usuarios"][user_id] = {
             "nome": ctx.author.name,

--- a/views.py
+++ b/views.py
@@ -215,6 +215,15 @@ class DistribuiPontosView(discord.ui.View):
         }
         self.finalizado = False
 
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message(
+                "🐾 **Lulu:** Ei! Não toque nos atributos dos outros. Crie sua própria ficha!", 
+                ephemeral=True
+            )
+            return False
+        return True    
+
     def gerar_embed(self):
         embed = discord.Embed(
             title="✨ Distribuição de Atributos",
@@ -307,7 +316,7 @@ class DistribuiPontosView(discord.ui.View):
     async def confirmar(self, interaction, button):
         if self.pontos_restantes == 0:
             self.finalizado = True
-            await interaction.response.send_message("✅ Atributos confirmados!", ephemeral=True)
+            await interaction.response.edit_message(content="✅ **Ficha Finalizada!** Seus atributos foram salvos.", view=None, embed=self.gerar_embed())
             self.stop()
         else:
             await interaction.response.send_message(f"Ainda restam {self.pontos_restantes} pontos para distribuir!", ephemeral=True)


### PR DESCRIPTION
Adicionada uma verificação de interação em DistribuiPontosView para impedir que usuários que não sejam o autor do comando editem a distribuição de atributos. Melhorada a mensagem de confirmação para indicar a conclusão e exibir os atributos finais. Removidos comentários desnecessários de sistema.py para um código mais limpo.