### PR TITLE
Refatora comentários e adicionar autocompletar itens beber

### DIFF
--- a/cogs/habilidades.py
+++ b/cogs/habilidades.py
@@ -40,21 +40,18 @@ class Habilidades(commands.Cog):
         user_id = str(interaction.user.id)
         habilidades = self._obter_habilidades_usuario(user_id)
         
-        # Filtra as habilidades que correspondem ao texto digitado
         opcoes = [
             discord.app_commands.Choice(name=hab, value=hab)
             for hab in habilidades
             if current.lower() in hab.lower()
         ]
         
-        # Discord limita a 25 opções no autocomplete
         return opcoes[:25]
 
     @commands.hybrid_command(name="usar", description="Usa uma habilidade ou lista as disponíveis")
     @discord.app_commands.describe(habilidade="Nome da habilidade (deixe vazio para ver a lista)")
     @discord.app_commands.autocomplete(habilidade=habilidade_autocomplete)
     async def usar(self, ctx, *, habilidade: str = None):
-        # 1. Carregamento de dados frescos
         user_id = str(ctx.author.id)
         dados = carregar_dados()
         p = dados["usuarios"].get(user_id)
@@ -65,20 +62,16 @@ class Habilidades(commands.Cog):
         raca = p.get("raca")
         nivel = p.get("nivel", 1)
 
-        # 2. Mapeamento de Habilidades Liberadas (Baseado na sua tabela em constantes.py)
         hab_liberadas = []
         if raca in constantes.HABILIDADES_RACA:
             for faixa, lista in constantes.HABILIDADES_RACA[raca].items():
                 try:
-                    # Converte "1-2" -> inicio=1
                     inicio_faixa = int(faixa.split('-')[0])
-                    # Se o nível do jogador atingiu ou passou o início da faixa, ele conhece as habs
                     if nivel >= inicio_faixa:
                         hab_liberadas.extend(lista)
                 except Exception as e:
                     print(f"Erro ao ler faixa {faixa}: {e}")
 
-        # --- LÓGICA DE LISTAGEM (Caso o usuário não digite o nome da habilidade) ---
         if not habilidade or habilidade.strip() == "":
             if not hab_liberadas:
                 return await ctx.send(f"🐾 **Lulu:** Como um **{raca}** nível **{nivel}**, você ainda não despertou habilidades.")
@@ -88,7 +81,6 @@ class Habilidades(commands.Cog):
                 description=f"Seu sangue **{raca}** (Lvl {nivel}) permite usar:",
                 color=0x3498db
             )
-            # Formata a lista para o Embed
             texto_formatado = "\n".join([f"✨ **{h}**" for h in hab_liberadas])
             embed_lista.add_field(name="Grimório de Técnicas", value=texto_formatado)
             embed_lista.set_footer(text="Use !usar [nome] para ativar")
@@ -96,7 +88,6 @@ class Habilidades(commands.Cog):
             return await ctx.send(embed=embed_lista)
 
         # --- BUSCA DA HABILIDADE DIGITADA ---
-        # Remove aspas e espaços extras, busca ignorando maiúsculas
         hab_limpa = habilidade.replace('"', '').replace("'", "").strip().lower()
         hab_nome_original = next((h for h in hab_liberadas if h.lower() == hab_limpa), None)
 
@@ -111,7 +102,6 @@ class Habilidades(commands.Cog):
             
             with open("habilidades.json", "r", encoding="utf-8") as f:
                 biblioteca = json.load(f)
-                # O .get(hab_nome_original) garante que usemos o nome com as maiúsculas corretas do JSON
                 dados_hab = biblioteca.get(raca, {}).get(hab_nome_original)
 
             if not dados_hab:
@@ -122,7 +112,6 @@ class Habilidades(commands.Cog):
             azar_msg = "⚠️ **O Azar te atingiu! (-5 na rolagem)**\n" if p.get("azarado") else ""
             if p.get("azarado"): p["azarado"] = False
 
-            # Executa a lógica matemática (HabilidadesLogic)
             res = processar_uso_habilidade(p, dados_hab, mod)
             
             embed = discord.Embed(title=f"✨ {p['nome']} usou {hab_nome_original}")
@@ -132,18 +121,15 @@ class Habilidades(commands.Cog):
             if mod != 0: info_calculo += f" - 5 (Azar)"
             info_calculo += f" = **{res['total']}**"
 
-            # 5. RESULTADOS (Sucesso)
             if res["sucesso"]:
                 embed.color = discord.Color.green()
                 if res["cura"] > 0:
-                    # Limita a cura ao PV Máximo estático da ficha
                     pv_max = p.get("pv_max", 30)
                     p["pv"] = min(pv_max, p["pv"] + res["cura"])
                     embed.description = f"{azar_msg}✅ **Sucesso!**\n{info_calculo} (DT: {res['dt_aplicada']})\n\n*{dados_hab['descricao']}*\n\n💖 **Cura:** +{res['cura']} PV | ❤️ **Vida:** {p['pv']}/{pv_max}"
                 else:
                     embed.description = f"{azar_msg}✅ **Sucesso!**\n{info_calculo} (DT: {res['dt_aplicada']})\n\n*{dados_hab['descricao']}*\n\n⚔️ **Dano:** {res['dano']}"
             
-            # 6. RESULTADOS (Falha)
             else:
                 import random
                 d4 = random.randint(1, 4)
@@ -161,7 +147,6 @@ class Habilidades(commands.Cog):
             if res["logs"]:
                 embed.add_field(name="🎒 Itens Utilizados", value="\n".join([f"• {log}" for log in res["logs"]]), inline=False)
 
-            # Salva todas as alterações (PV, Azar, etc)
             salvar_dados(dados)
             await ctx.send(embed=embed)
 


### PR DESCRIPTION
Remove comentários redundantes de habilidades.py e players.py para um código mais limpo. Adicionei autocompletar para o comando 'beber', restringindo os itens utilizáveis ​​a uma lista definida e implementando efeitos específicos para cada item consumível em players.py.